### PR TITLE
FEAT: Reservation 도메인 추가

### DIFF
--- a/src/main/java/com/knu/cse/classroom/domain/Building.java
+++ b/src/main/java/com/knu/cse/classroom/domain/Building.java
@@ -1,0 +1,5 @@
+package com.knu.cse.classroom.domain;
+
+public enum Building {
+    IT4, IT5
+}

--- a/src/main/java/com/knu/cse/classroom/domain/ClassRoom.java
+++ b/src/main/java/com/knu/cse/classroom/domain/ClassRoom.java
@@ -1,0 +1,34 @@
+package com.knu.cse.classroom.domain;
+
+import com.knu.cse.classseat.domain.ClassSeat;
+import com.knu.cse.reservation.domain.Reservation;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "CLASS_ROOM")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class ClassRoom {
+
+    @Id @GeneratedValue
+    @Column(name = "room_id")
+    private Long id;
+
+    private Long number;
+
+    @Enumerated(EnumType.STRING)
+    private Building building;
+
+    private Long totalSeats;
+
+//    @OneToMany(mappedBy = "classRoom",fetch = FetchType.EAGER,cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "classRoom")
+    private List<ClassSeat> classSeats;
+
+}

--- a/src/main/java/com/knu/cse/classroom/repository/ClassRoomRepository.java
+++ b/src/main/java/com/knu/cse/classroom/repository/ClassRoomRepository.java
@@ -1,0 +1,8 @@
+package com.knu.cse.classroom.repository;
+
+import com.knu.cse.classroom.domain.ClassRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClassRoomRepository extends JpaRepository<ClassRoom, Long> {
+
+}

--- a/src/main/java/com/knu/cse/member/model/Member.java
+++ b/src/main/java/com/knu/cse/member/model/Member.java
@@ -2,11 +2,15 @@ package com.knu.cse.member.model;
 
 import com.knu.cse.base.BaseTimeEntity;
 import javax.persistence.*;
+
+import com.knu.cse.reservation.domain.Reservation;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.List;
 
 @Entity
 @Builder
@@ -33,5 +37,8 @@ public class Member extends BaseTimeEntity {
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     private MemberRole role = MemberRole.ROLE_NOT_PERMITTED;
+
+    @OneToMany(mappedBy = "member")
+    private List<Reservation> reservations;
 
 }

--- a/src/main/java/com/knu/cse/member/repository/MemberRepository.java
+++ b/src/main/java/com/knu/cse/member/repository/MemberRepository.java
@@ -1,0 +1,2 @@
+package com.knu.cse.member.repository;public interface MemberRepository {
+}

--- a/src/main/java/com/knu/cse/reservation/domain/Reservation.java
+++ b/src/main/java/com/knu/cse/reservation/domain/Reservation.java
@@ -1,0 +1,44 @@
+package com.knu.cse.reservation.domain;
+
+import com.knu.cse.classseat.domain.ClassSeat;
+import com.knu.cse.member.model.Member;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Reservation {
+
+    @Id @GeneratedValue
+    @Column(name="reservation_id")
+    private Long id;
+
+    private LocalDateTime dueDate;
+    private Long extensionNum;
+
+    @OneToOne
+    @JoinColumn(name = "seat_id")
+    private ClassSeat classSeat;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public void setMember(Member member){
+        if (this.member != null){
+            this.member.getReservations().remove(this);
+        }
+        this.member = member;
+        member.getReservations().add(this);
+    }
+
+    public Reservation(LocalDateTime dueDate, Long extensionNum, ClassSeat classSeat, Member member){
+        this.dueDate = dueDate;
+        this.extensionNum = extensionNum;
+        this.classSeat = classSeat;
+        setMember(member);
+    }
+
+}

--- a/src/main/java/com/knu/cse/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/knu/cse/reservation/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package com.knu.cse.reservation.repository;
+
+import com.knu.cse.member.repository.MemberRepository;
+import com.knu.cse.reservation.domain.Reservation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/test/java/com/knu/cse/reservation/domain/ReservationTest.java
+++ b/src/test/java/com/knu/cse/reservation/domain/ReservationTest.java
@@ -1,0 +1,4 @@
+import static org.junit.Assert.*;
+public class ReservationTest {
+  
+}


### PR DESCRIPTION
## 수정사항내용
1. Reservation 도메인(연관관계 매핑, 연관관계 편의 메소드)
2. Member 도메인에 Reservation 연관관계 매핑 추가
3. ReservationRepository(CRUD with spring data JPA)