### PR TITLE
FIX: writeBoard,wirteComment,Comment 연관관계정의 메소드 수정

### DIFF
--- a/src/main/java/com/knu/cse/board/domain/WriteBoard.java
+++ b/src/main/java/com/knu/cse/board/domain/WriteBoard.java
@@ -32,7 +32,7 @@ public class WriteBoard extends BaseTimeEntity {
 
     public void setMember(Member member){
         if(member.getId()!=null){
-            member.getBoardList().remove(this);
+            this.member.getBoardList().remove(this);
         }
         this.member=member;
         member.getBoardList().add(this);
@@ -40,7 +40,7 @@ public class WriteBoard extends BaseTimeEntity {
 
     public void setBoard(Board board){
         if(board.getId()!=null){
-            board.getWriterList().remove(this);
+            this.board.getWriterList().remove(this);
         }
         this.board=board;
         board.getWriterList().add(this);

--- a/src/main/java/com/knu/cse/comment/domain/Comment.java
+++ b/src/main/java/com/knu/cse/comment/domain/Comment.java
@@ -42,7 +42,7 @@ public class Comment extends BaseTimeEntity {
 
     public void setBoard(Board board){
         if(board.getId()!=null){
-            board.getCommentList().remove(this);
+            this.board.getCommentList().remove(this);
         }
         this.board=board;
         board.getCommentList().add(this);

--- a/src/main/java/com/knu/cse/comment/domain/WriteComment.java
+++ b/src/main/java/com/knu/cse/comment/domain/WriteComment.java
@@ -29,7 +29,7 @@ public class WriteComment extends BaseTimeEntity {
 
     public void setMember(Member member){
         if(member.getId()!=null){
-            member.getCommentList().remove(this);
+            this.member.getCommentList().remove(this);
         }
         this.member=member;
         member.getCommentList().add(this);
@@ -37,7 +37,7 @@ public class WriteComment extends BaseTimeEntity {
 
     public void setComment(Comment comment){
         if(comment.getId()!=null){
-            comment.getCommenterList().remove(this);
+            this.comment.getCommenterList().remove(this);
         }
         this.comment=comment;
         comment.getCommenterList().add(this);


### PR DESCRIPTION
## Pull Request

## 종류

- [ ] New Feature
- [x] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용

- writeBoard,wirteComment,Comment 연관관계정의 메소드 수정


## 변경로직

- setBoard,setComment의 메소드에서 만약 Board와 Comment의 식별자가 존재하면 
this.member.writeBoardList()에서 현재 객체를 제거해야하는데, `this`를 누락하였음
