### PR TITLE
FEAT: 프로필 이미지 등록 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.knu.cse.member.dto.SignUpForm;
 import com.knu.cse.email.service.AuthService;
 
 import com.knu.cse.member.repository.MemberRepository;
+import com.knu.cse.member.service.MemberService;
 import com.knu.cse.utils.ApiUtils.ApiResult;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.Cookie;
@@ -21,13 +22,16 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
 import static com.knu.cse.utils.ApiUtils.success;
 
 @RestController
@@ -38,6 +42,7 @@ public class MemberController {
 
     private final AuthService authService;
     private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final JwtUtil jwtUtil;
     private final CookieUtil cookieUtil;
     private final RedisUtil redisUtil;
@@ -79,10 +84,19 @@ public class MemberController {
         return success(permissionCode);
     }
 
-    @ApiOperation(value = "회원 E-mail과 Nickname, userId 반환", notes="현재 로그인한 유저의 정보(닉네임, 이메일, 회원 번호)을 반환하는 API")
+    @ApiOperation(value = "(E-mail, Nickname, userId, 프로필 이미지) 반환", notes="현재 로그인한 유저의 정보(닉네임, 이메일, 회원 번호, 프로필 이미지)를 반환하는 API")
     @GetMapping("/getUserEmailNickname")
     public ApiResult<MemberDto> getEmailNickname(HttpServletRequest req){
         Long userId = authService.getUserIdFromJWT(req);
         return success(new MemberDto(memberRepository.findById(userId).orElseThrow(()-> new NotFoundException ("존재하지 않는 회원입니다."))));
     }
+
+    @ApiOperation(value = "프로필 이미지 변경", notes = "프로필 이미지를 파일 형태로 전송하여 저장할 수 있다.")
+    @PutMapping("/profileImage")
+    public ApiResult<String> uploadProfileImage(@RequestParam MultipartFile file, HttpServletRequest req)
+        throws Exception {
+        Long userId = authService.getUserIdFromJWT(req);
+        return success(memberService.updateProfileImage(file, userId));
+    }
+
 }

--- a/src/main/java/com/knu/cse/member/dto/MemberDto.java
+++ b/src/main/java/com/knu/cse/member/dto/MemberDto.java
@@ -9,10 +9,12 @@ public class MemberDto {
     private Long userId;
     private String email;
     private String nickname;
+    private String imagePath;
 
     public MemberDto(Member member) {
         this.userId = member.getId();
         this.email = member.getEmail();
         this.nickname = member.getNickname();
+        this.imagePath = member.getProfileImageUrl();
     }
 }

--- a/src/main/java/com/knu/cse/member/model/Member.java
+++ b/src/main/java/com/knu/cse/member/model/Member.java
@@ -28,6 +28,7 @@ public class Member extends BaseEntity {
     private String username;
     private String nickname;
     private String studentId;
+    private String profileImageUrl;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
@@ -51,4 +52,8 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy="member")
     private List<Comment> commentList;
+
+    public void changeProfileImage(String imagePath){
+        this.profileImageUrl = imagePath;
+    }
 }

--- a/src/main/java/com/knu/cse/member/service/MemberService.java
+++ b/src/main/java/com/knu/cse/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package com.knu.cse.member.service;
+
+import com.knu.cse.errors.NotFoundException;
+import com.knu.cse.image.S3UploadService;
+import com.knu.cse.member.model.Member;
+import com.knu.cse.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final S3UploadService uploadService;
+
+    @Transactional
+    public String updateProfileImage(MultipartFile file, Long userId) throws Exception {
+        Member member = memberRepository.findById(userId).orElseThrow(()->
+            new NotFoundException("존재하지 않는 회원입니다."));
+        String imagePath = uploadService.upload(file, "static");
+        member.changeProfileImage(imagePath);
+        return imagePath;
+    }
+}


### PR DESCRIPTION
## Pull Request

## 종류

- [X] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
- 프로필 이미지 등록 기능 구현

- 프로필 이미지 조회 기능 구현

## 변경 로직
- Member 엔티티 내에 profileImageUrl  필드, 변경 도메인 메소드 추가

- DTO 조회 시 프로필 이미지도 포함

- 이미지 관련 컨트롤러, 서비스 추가
