### PR TITLE
Feat: 비밀번호 변경 기능 추가

### DIFF
--- a/src/main/java/com/knu/cse/email/service/AuthService.java
+++ b/src/main/java/com/knu/cse/email/service/AuthService.java
@@ -127,4 +127,29 @@ public class AuthService {
         String email = new String(Base64.getDecoder().decode(encodedPayload)).split("\"")[3];
         return findByEmail(email).getId();
     }
+
+    public String getPasswordFromJWT(HttpServletRequest req) throws NotFoundException{
+        String claim = "";
+        for (Cookie cookie : req.getCookies()) {
+            if(cookie.getName().equals("accessToken")){
+                claim = cookie.getValue();
+                break;
+            }
+        }
+        int start = claim.indexOf(".") + 1;
+        int end = claim.lastIndexOf(".");
+        if(start == -1 || end == -1){
+            throw new NotFoundException("아직 JWT 토큰을 발급받지 않은 상태입니다." + claim);
+        }
+        String encodedPayload = claim.substring(start, end);
+        String email = new String(Base64.getDecoder().decode(encodedPayload)).split("\"")[3];
+        return findByEmail(email).getPassword();
+    }
+
+    public boolean comparePassword(String rawPassword, String encodedPassword) throws NotFoundException{
+        boolean matcheResult = passwordEncoder.matches(rawPassword, encodedPassword);
+        if(!matcheResult)
+            throw new NotFoundException("비밀번호가 틀립니다.");
+        return true;
+    }
 }

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -98,9 +98,7 @@ public class MemberController {
     @ApiOperation(value = "비밀번호 변경", notes = "changePassword(String) : 변경하고자하는 비밀번호, currentPassword(String) : 현재 비밀번호 를 넘겨주면 validation 후 비밀번호 변경.")
     @PutMapping("/changePassword")
     public ApiResult<String> changePassword(@Valid @RequestBody ChangePasswordForm changePasswordForm, HttpServletRequest req){
-        log.info("change : " + changePasswordForm.getChangePassword()+", current : "+changePasswordForm.getCurrentPassword());
         String encodedPassword = authService.getPasswordFromJWT(req);
-        log.info("password : " + encodedPassword);
         Long userId = authService.getUserIdFromJWT(req);
         authService.comparePassword(changePasswordForm.getCurrentPassword(),encodedPassword);
         memberService.changePassword(changePasswordForm.getChangePassword(), userId);

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -4,12 +4,8 @@ import com.knu.cse.email.util.CookieUtil;
 import com.knu.cse.email.util.JwtUtil;
 import com.knu.cse.email.util.RedisUtil;
 import com.knu.cse.errors.NotFoundException;
-import com.knu.cse.member.dto.LoginSuccessDto;
-import com.knu.cse.member.dto.MemberDto;
-import com.knu.cse.member.dto.VerifyEmailDto;
+import com.knu.cse.member.dto.*;
 import com.knu.cse.member.model.Member;
-import com.knu.cse.member.dto.SignInForm;
-import com.knu.cse.member.dto.SignUpForm;
 import com.knu.cse.email.service.AuthService;
 
 import com.knu.cse.member.repository.MemberRepository;
@@ -97,6 +93,18 @@ public class MemberController {
         throws Exception {
         Long userId = authService.getUserIdFromJWT(req);
         return success(memberService.updateProfileImage(file, userId));
+    }
+
+    @ApiOperation(value = "비밀번호 변경", notes = "changePassword(String) : 변경하고자하는 비밀번호, currentPassword(String) : 현재 비밀번호 를 넘겨주면 validation 후 비밀번호 변경.")
+    @PutMapping("/changePassword")
+    public ApiResult<String> changePassword(@Valid @RequestBody ChangePasswordForm changePasswordForm, HttpServletRequest req){
+        log.info("change : " + changePasswordForm.getChangePassword()+", current : "+changePasswordForm.getCurrentPassword());
+        String encodedPassword = authService.getPasswordFromJWT(req);
+        log.info("password : " + encodedPassword);
+        Long userId = authService.getUserIdFromJWT(req);
+        authService.comparePassword(changePasswordForm.getCurrentPassword(),encodedPassword);
+        memberService.changePassword(changePasswordForm.getChangePassword(), userId);
+        return success("성공적으로 비밀번호를 변경했습니다.");
     }
 
 }

--- a/src/main/java/com/knu/cse/member/dto/ChangePasswordForm.java
+++ b/src/main/java/com/knu/cse/member/dto/ChangePasswordForm.java
@@ -1,0 +1,23 @@
+package com.knu.cse.member.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@NoArgsConstructor
+public class ChangePasswordForm {
+    private String currentPassword;
+
+    @NotNull
+    @Length(min = 8, max = 20, message = "비밀번호의 길이는 8에서 20사이여야 합니다!")
+    private String changePassword;
+
+    public ChangePasswordForm(String currentPassword,
+                              @NotNull @Length(min = 8, max = 20) String changePassword){
+        this.currentPassword = currentPassword;
+        this.changePassword = changePassword;
+    }
+}

--- a/src/main/java/com/knu/cse/member/model/Member.java
+++ b/src/main/java/com/knu/cse/member/model/Member.java
@@ -65,4 +65,6 @@ public class Member extends BaseEntity {
     public void changeProfileImage(String imagePath){
         this.profileImageUrl = imagePath;
     }
+
+    public void changePassword(String password){this.password = password;}
 }

--- a/src/main/java/com/knu/cse/member/service/MemberService.java
+++ b/src/main/java/com/knu/cse/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.knu.cse.image.S3UploadService;
 import com.knu.cse.member.model.Member;
 import com.knu.cse.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,6 +16,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final S3UploadService uploadService;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public String updateProfileImage(MultipartFile file, Long userId) throws Exception {
@@ -24,4 +26,13 @@ public class MemberService {
         member.changeProfileImage(imagePath);
         return imagePath;
     }
+
+    @Transactional
+    public void changePassword(String password, Long userId) throws NotFoundException{
+        Member member = memberRepository.findById(userId).orElseThrow(
+                () -> new NotFoundException("존재하지 않는 회원입니다."));
+        member.changePassword(passwordEncoder.encode(password));
+    }
+
+
 }


### PR DESCRIPTION
## Pull Request

## 종류

- [x] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
ChangePasswordForm
- 비밀번호 변경 DTO
changePassword API 
- PutMapping / changePassword(String) : 변경하고자하는 비밀번호, currentPassword(String) : 현재 비밀번호 를 넘겨주면 validation 후 비밀번호 변경.
changePassword
- 변경하고자하는 비밀번호를 암호화 후 변경
comparePassword
- authService에서 로그인된 유저의 비밀번호와 현재 비밀번호가 일치하는지 검사.
getPasswordFromJWT
- JWT에서 비밀번호를 얻어옴

## 변경로직
x

