### PR TITLE
FIX: SecurityContextHolder를 사용해 JWT 인증

### DIFF
--- a/src/main/java/com/knu/cse/board/controller/BoardController.java
+++ b/src/main/java/com/knu/cse/board/controller/BoardController.java
@@ -40,7 +40,7 @@ public class BoardController {
     @PostMapping("/write")
     public ApiResult<BoardDto> writeBoard(@RequestBody BoardForm boardForm, HttpServletRequest req)
         throws NotFoundException {
-        Long userId = authService.getUserIdFromJWT(req);
+        Long userId = authService.getUserIdFromJWT();
         return success(new BoardDto(boardService.writeBoard(userId, boardForm)));
     }
 
@@ -113,7 +113,7 @@ public class BoardController {
     @ApiOperation(value = "내가 작성한 게시물 조회", notes = "내가 작성한 모든 게시물을 조회한다.")
     @GetMapping("/findMyBoards")
     public ApiResult<List<BoardDto>> findMyBoards(HttpServletRequest req){
-        Long userId = authService.getUserIdFromJWT(req);
-        return success(boardService.findMyBoards(userId));
+        Long memId = authService.getUserIdFromJWT();
+        return success(boardService.findMyBoards(memId));
     }
 }

--- a/src/main/java/com/knu/cse/board/controller/BoardController.java
+++ b/src/main/java/com/knu/cse/board/controller/BoardController.java
@@ -38,7 +38,7 @@ public class BoardController {
 
     @ApiOperation(value = "게시물 글 작성", notes = "로그인을 한 유저가 게시물에 글을 작성 할 수 있다.")
     @PostMapping("/write")
-    public ApiResult<BoardDto> writeBoard(@RequestBody BoardForm boardForm, HttpServletRequest req)
+    public ApiResult<BoardDto> writeBoard(@RequestBody BoardForm boardForm)
         throws NotFoundException {
         Long userId = authService.getUserIdFromJWT();
         return success(new BoardDto(boardService.writeBoard(userId, boardForm)));
@@ -52,9 +52,9 @@ public class BoardController {
 
     @ApiOperation(value = "게시물 기본키로 글 삭제", notes = "게시물을 작성한 사람은 게시물을 삭제 할 수 있다.")
     @DeleteMapping("/{boardId}")
-    public ApiResult<String> deleteBoard(@PathVariable("boardId") Long boardId,HttpServletRequest req) throws NotFoundException{
+    public ApiResult<String> deleteBoard(@PathVariable("boardId") Long boardId) throws NotFoundException{
         try{
-            Long userId = authService.getUserIdFromJWT(req);
+            Long userId = authService.getUserIdFromJWT();
             boardService.deleteBoard(userId,boardId);
             return success("게시물이 성공적으로 삭제되었습니다.");
         }
@@ -68,9 +68,9 @@ public class BoardController {
 
     @ApiOperation(value = "게시물 기본키로 글 수정", notes = "게시물을 작성한 사람은 게시물을 수정 할 수 있다. 제목이나 내용 중 수정하지 않으려는 것은 null이나 빈문자열로 보내야 한다")
     @PutMapping("/{boardId}")
-    public ApiResult<String> editBoard(@PathVariable("boardId") Long boardId,@RequestBody BoardForm boardForm,HttpServletRequest req) throws NotFoundException{
+    public ApiResult<String> editBoard(@PathVariable("boardId") Long boardId,@RequestBody BoardForm boardForm) throws NotFoundException{
         try{
-            Long userId = authService.getUserIdFromJWT(req);
+            Long userId = authService.getUserIdFromJWT();
             boardService.updateBoard(userId,boardId,boardForm);
             return success("게시물이 성공적으로 수정되었습니다.");
         }
@@ -112,7 +112,7 @@ public class BoardController {
 
     @ApiOperation(value = "내가 작성한 게시물 조회", notes = "내가 작성한 모든 게시물을 조회한다.")
     @GetMapping("/findMyBoards")
-    public ApiResult<List<BoardDto>> findMyBoards(HttpServletRequest req){
+    public ApiResult<List<BoardDto>> findMyBoards(){
         Long memId = authService.getUserIdFromJWT();
         return success(boardService.findMyBoards(memId));
     }

--- a/src/main/java/com/knu/cse/comment/controller/CommentController.java
+++ b/src/main/java/com/knu/cse/comment/controller/CommentController.java
@@ -36,7 +36,7 @@ public class CommentController {
     @PostMapping("/write")
     public ApiResult<CommentDto> writeComment(@RequestBody CommentForm commentForm,
         HttpServletRequest req) throws NotFoundException {
-        Long memberId = authService.getUserIdFromJWT(req);
+        Long memberId = authService.getUserIdFromJWT();
 
         return success(new CommentDto(commentService.writeComment(memberId, commentForm)));
     }
@@ -44,7 +44,7 @@ public class CommentController {
     @PostMapping("/reply/write")
     public ApiResult<CommentDto> writeReply(@RequestBody ReplyForm replyForm,
         HttpServletRequest req) throws NotFoundException {
-        Long memberId = authService.getUserIdFromJWT(req);
+        Long memberId = authService.getUserIdFromJWT();
 
         return success(new CommentDto(commentService.writeReply(memberId, replyForm)));
     }
@@ -52,7 +52,7 @@ public class CommentController {
     @ApiOperation(value = "내가 쓴 댓글 조회", notes = "내가 쓴 댓글을 모두 조회한다.")
     @GetMapping("/getAllComments")
     public ApiResult<List<CommentDto>> getMyAllWrite(HttpServletRequest req) throws NotFoundException {
-        Long memberId = authService.getUserIdFromJWT(req);
+        Long memberId = authService.getUserIdFromJWT();
         return success(commentService.findMyComments(memberId).stream().map(CommentDto::new)
             .collect(Collectors.toList()));
     }
@@ -68,7 +68,7 @@ public class CommentController {
     public ApiResult<String> editComment(@PathVariable("commentId") Long commentId, @RequestBody CommentForm commentForm,
         HttpServletRequest req) {
         try {
-            Long memberId = authService.getUserIdFromJWT(req);
+            Long memberId = authService.getUserIdFromJWT();
             commentService.updateComment(memberId,commentId,commentForm);
 
             return success("수정이 완료되었습니다.");
@@ -87,7 +87,7 @@ public class CommentController {
         HttpServletRequest req){
 
         try {
-            Long memberId = authService.getUserIdFromJWT(req);
+            Long memberId = authService.getUserIdFromJWT();
             commentService.deleteComment(memberId,commentId);
 
             return success("댓글 삭제가 완료되었니다.");

--- a/src/main/java/com/knu/cse/email/service/AuthService.java
+++ b/src/main/java/com/knu/cse/email/service/AuthService.java
@@ -119,22 +119,11 @@ public class AuthService {
             new NotFoundException("존재하지 않는 회원입니다.")).getId();
     }
 
-    public String getPasswordFromJWT(HttpServletRequest req) throws NotFoundException{
-        String claim = "";
-        for (Cookie cookie : req.getCookies()) {
-            if(cookie.getName().equals("accessToken")){
-                claim = cookie.getValue();
-                break;
-            }
-        }
-        int start = claim.indexOf(".") + 1;
-        int end = claim.lastIndexOf(".");
-        if(start == -1 || end == -1){
-            throw new NotFoundException("아직 JWT 토큰을 발급받지 않은 상태입니다." + claim);
-        }
-        String encodedPayload = claim.substring(start, end);
-        String email = new String(Base64.getDecoder().decode(encodedPayload)).split("\"")[3];
-        return findByEmail(email).getPassword();
+    public String getPasswordFromJwt() throws NotFoundException {
+        SecurityMember securityMember = (SecurityMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String email = securityMember.getEmail();
+        return memberRepository.findByEmail(email).orElseThrow(()->
+            new NotFoundException("존재하지 않는 회원입니다.")).getPassword();
     }
 
     public boolean comparePassword(String rawPassword, String encodedPassword) throws NotFoundException{

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -13,7 +13,6 @@ import com.knu.cse.member.service.MemberService;
 import com.knu.cse.utils.ApiUtils.ApiResult;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
 import static com.knu.cse.utils.ApiUtils.success;
 
 @RestController
@@ -82,14 +80,14 @@ public class MemberController {
 
     @ApiOperation(value = "(E-mail, Nickname, userId, 프로필 이미지) 반환", notes="현재 로그인한 유저의 정보(닉네임, 이메일, 회원 번호, 프로필 이미지)를 반환하는 API")
     @GetMapping("/getUserEmailNickname")
-    public ApiResult<MemberDto> getEmailNickname(HttpServletRequest req){
+    public ApiResult<MemberDto> getEmailNickname(){
         Long userId = authService.getUserIdFromJWT();
         return success(new MemberDto(memberRepository.findById(userId).orElseThrow(()-> new NotFoundException ("존재하지 않는 회원입니다."))));
     }
 
     @ApiOperation(value = "프로필 이미지 변경", notes = "프로필 이미지를 파일 형태로 전송하여 저장할 수 있다.")
     @PutMapping("/profileImage")
-    public ApiResult<String> uploadProfileImage(@RequestParam MultipartFile file, HttpServletRequest req)
+    public ApiResult<String> uploadProfileImage(@RequestParam MultipartFile file)
         throws Exception {
         Long userId = authService.getUserIdFromJWT();
         return success(memberService.updateProfileImage(file, userId));
@@ -97,8 +95,8 @@ public class MemberController {
 
     @ApiOperation(value = "비밀번호 변경", notes = "changePassword(String) : 변경하고자하는 비밀번호, currentPassword(String) : 현재 비밀번호 를 넘겨주면 validation 후 비밀번호 변경.")
     @PutMapping("/changePassword")
-    public ApiResult<String> changePassword(@Valid @RequestBody ChangePasswordForm changePasswordForm, HttpServletRequest req){
-        String encodedPassword = authService.getPasswordFromJWT(req);
+    public ApiResult<String> changePassword(@Valid @RequestBody ChangePasswordForm changePasswordForm){
+        String encodedPassword = authService.getPasswordFromJwt();
         Long userId = authService.getUserIdFromJWT();
         authService.comparePassword(changePasswordForm.getCurrentPassword(),encodedPassword);
         memberService.changePassword(changePasswordForm.getChangePassword(), userId);

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -74,7 +74,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "이메일 인증", notes="회원가입 시 이메일로 전송한 인증 번호를 확인하는 API")
-    @PostMapping("/verify/")
+    @PostMapping("/verify")
     public ApiResult<String> getVerify(@RequestBody VerifyEmailDto verifyEmailDto) throws IllegalStateException{
         String permissionCode = authService.verifyEmail(verifyEmailDto);
         return success(permissionCode);
@@ -83,7 +83,7 @@ public class MemberController {
     @ApiOperation(value = "(E-mail, Nickname, userId, 프로필 이미지) 반환", notes="현재 로그인한 유저의 정보(닉네임, 이메일, 회원 번호, 프로필 이미지)를 반환하는 API")
     @GetMapping("/getUserEmailNickname")
     public ApiResult<MemberDto> getEmailNickname(HttpServletRequest req){
-        Long userId = authService.getUserIdFromJWT(req);
+        Long userId = authService.getUserIdFromJWT();
         return success(new MemberDto(memberRepository.findById(userId).orElseThrow(()-> new NotFoundException ("존재하지 않는 회원입니다."))));
     }
 
@@ -91,7 +91,7 @@ public class MemberController {
     @PutMapping("/profileImage")
     public ApiResult<String> uploadProfileImage(@RequestParam MultipartFile file, HttpServletRequest req)
         throws Exception {
-        Long userId = authService.getUserIdFromJWT(req);
+        Long userId = authService.getUserIdFromJWT();
         return success(memberService.updateProfileImage(file, userId));
     }
 
@@ -99,10 +99,9 @@ public class MemberController {
     @PutMapping("/changePassword")
     public ApiResult<String> changePassword(@Valid @RequestBody ChangePasswordForm changePasswordForm, HttpServletRequest req){
         String encodedPassword = authService.getPasswordFromJWT(req);
-        Long userId = authService.getUserIdFromJWT(req);
+        Long userId = authService.getUserIdFromJWT();
         authService.comparePassword(changePasswordForm.getCurrentPassword(),encodedPassword);
         memberService.changePassword(changePasswordForm.getChangePassword(), userId);
         return success("성공적으로 비밀번호를 변경했습니다.");
     }
-
 }

--- a/src/main/java/com/knu/cse/member/security/SecurityMember.java
+++ b/src/main/java/com/knu/cse/member/security/SecurityMember.java
@@ -8,7 +8,11 @@ public class SecurityMember extends User {
     private static final long serialVersionUiD = 1L;
 
     public SecurityMember(Member member){
-        super(member.getUsername(),"{noop}"+ member.getPassword(), AuthorityUtils
+        super(member.getEmail(),"{noop}"+ member.getPassword(), AuthorityUtils
             .createAuthorityList(member.getRole().toString()));
+    }
+
+    public String getEmail(){
+        return super.getUsername();
     }
 }

--- a/src/main/java/com/knu/cse/reservation/controller/ReservationController.java
+++ b/src/main/java/com/knu/cse/reservation/controller/ReservationController.java
@@ -37,7 +37,7 @@ public class ReservationController {
     @ApiOperation(value = "예약한 좌석 반납하기", notes="로그인 된 세션을 바탕으로 좌석 반납함.")
     @PostMapping("/delete")
     public ApiResult<String> deleteReservation(HttpServletRequest request) throws NotFoundException {
-        Long userId = authService.getUserIdFromJWT(request);
+        Long userId = authService.getUserIdFromJWT();
         Optional<Member> member = Optional.ofNullable(memberRepository.findById(userId).orElseThrow(
                 () -> new NotFoundException("등록된 회원이 아닙니다.")
         ));
@@ -50,7 +50,7 @@ public class ReservationController {
     @ApiOperation(value = "좌석 예약하기", notes="건물, 강의실 번호, 좌석 번호를 넘겨주면 로그인된 세션의 유저로 좌석을 예약함.")
     @PostMapping("/reservation")
     public ApiResult<String> reservation(@Valid @RequestBody ReservationDTO reservationDTO, HttpServletRequest request) throws Exception{
-        Long userId = authService.getUserIdFromJWT(request);
+        Long userId = authService.getUserIdFromJWT();
         Optional<Member> member = Optional.ofNullable(memberRepository.findById(userId).orElseThrow(
                 () -> new NotFoundException("등록된 회원이 아닙니다")
         ));
@@ -65,7 +65,7 @@ public class ReservationController {
     @ApiOperation(value = "현재 예약한 좌석 보기", notes="로그인된 세션의 유저의 예약 현황 보여줌")
     @PostMapping("/findReservation")
     public ApiResult<FindReservationDTO> findReservation(HttpServletRequest request) {
-        Long userId = authService.getUserIdFromJWT(request);
+        Long userId = authService.getUserIdFromJWT();
         FindReservationDTO findReservationDTO = reservationService.findReservation(userId);
         return success(findReservationDTO);
     }
@@ -73,7 +73,7 @@ public class ReservationController {
     @ApiOperation(value = "좌석 연장하기", notes="로그인된 세션의 유저의 좌석 연장함(최대3번)")
     @PostMapping("/extension")
     public ApiResult<Long> extension(HttpServletRequest request) throws Exception{
-        Long userId = authService.getUserIdFromJWT(request);
+        Long userId = authService.getUserIdFromJWT();
         Optional<Member> member = Optional.ofNullable(memberRepository.findById(userId).orElseThrow(
                 () -> new NotFoundException("등록된 회원이 아닙니다.")
         ));


### PR DESCRIPTION
## Pull Request

## 종류

- [ ] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [X] Refactor

## 작업 내용
- 기존에 쿠키에서 꺼내서 claim을 복호화 하던 과정 제거

- 컨트롤러 내에 불필요한 `HttpServletRequest` 파라미터 제거

## 변경로직
- `SecurityContextHolder`에서 `SecurityMember` 데이터를 꺼내서 인증 처리

