### PR TITLE
[#54] FEAT: 게시물에 해당하는 댓글을 조회할때, 답글은 댓글 객체에 포함되어 전달하도록 수정

### DIFF
--- a/src/main/java/com/knu/cse/comment/controller/CommentController.java
+++ b/src/main/java/com/knu/cse/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import com.knu.cse.errors.NotFoundException;
 import com.knu.cse.errors.UnauthorizedException;
 import com.knu.cse.utils.ApiUtils.ApiResult;
 import io.swagger.annotations.ApiOperation;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/com/knu/cse/comment/dto/CommentDto.java
+++ b/src/main/java/com/knu/cse/comment/dto/CommentDto.java
@@ -3,6 +3,8 @@ package com.knu.cse.comment.dto;
 import com.knu.cse.comment.domain.Comment;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -21,6 +23,8 @@ public class CommentDto {
 
     private String time;
 
+    private List<CommentDto> replyList;
+
     public CommentDto(Comment comment){
         this.boardId=comment.getBoard().getId();
         this.commentId = comment.getId();
@@ -29,5 +33,7 @@ public class CommentDto {
         this.time=comment.getLastModifiedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
         this.parentId=comment.getParentId();
     }
+
+    public void allocateReplyList() {this.replyList=new ArrayList<>();}
 
 }


### PR DESCRIPTION
## Pull Request

## 종류

- [x] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
- 게시물에 해당하는 댓글을 조회할때, 답글은 댓글 객체에 포함되어 전달하도록 수정

## 변경로직


