### PR TITLE
 FIX: comment의 commentID와 reply parentID를 비교할떄 동일성이 아닌 동등성 비교로 수정

### DIFF
--- a/src/main/java/com/knu/cse/comment/service/CommentService.java
+++ b/src/main/java/com/knu/cse/comment/service/CommentService.java
@@ -102,7 +102,7 @@ public class CommentService {
 
         for(CommentDto reply: replyList){
             for(CommentDto comment : commentList){
-                if(reply.getParentId()==comment.getCommentId()){
+                if(reply.getParentId().equals(comment.getCommentId())){
                     if(comment.getReplyList()==null) comment.allocateReplyList();
                     comment.getReplyList().add(reply);
                     break;


### PR DESCRIPTION
## Pull Request

## 종류

- [ ] New Feature
- [x] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
- comment의 commentID와 reply parentID를 비교할떄 동일성이 아닌 동등성 비교로 수정

## 변경로직

CommnetService의 105번째 줄 `==` 을 `equals()`로 수정
