### PR TITLE
FEAT: 닉네임 수정시 댓글 및 게시물 저자 변경 / 프로필 이미지 초기화

### DIFF
--- a/src/main/java/com/knu/cse/board/domain/Board.java
+++ b/src/main/java/com/knu/cse/board/domain/Board.java
@@ -77,4 +77,8 @@ public class Board extends BaseTimeEntity {
         this.author = "탈퇴한 회원입니다.";
     }
 
+    public void updateAuthor(String newAuthor){
+        this.author=changedInfo(this.author,newAuthor);
+    }
+
 }

--- a/src/main/java/com/knu/cse/board/service/BoardService.java
+++ b/src/main/java/com/knu/cse/board/service/BoardService.java
@@ -107,4 +107,9 @@ public class BoardService {
             new NotFoundException("존재하지 않는 회원입니다."))
             .stream().map(BoardDto::new).collect(Collectors.toList());
     }
+
+
+    public void updateBoardAuthor(Member member,String newNickName){
+        member.getBoardList().stream().forEach(o->o.updateAuthor(newNickName));
+    }
 }

--- a/src/main/java/com/knu/cse/comment/domain/Comment.java
+++ b/src/main/java/com/knu/cse/comment/domain/Comment.java
@@ -95,4 +95,8 @@ public class Comment extends BaseTimeEntity {
         this.author = "탈퇴한 회원입니다.";
     }
 
+    public void updateAuthor(String newAuthor){
+        this.author=changedInfo(this.author,newAuthor);
+    }
+
 }

--- a/src/main/java/com/knu/cse/comment/service/CommentService.java
+++ b/src/main/java/com/knu/cse/comment/service/CommentService.java
@@ -113,4 +113,9 @@ public class CommentService {
         return commentList;
     }
 
+
+    public void updateCommentAuthor(Member member,String newNickName){
+        member.getCommentList().forEach(o->o.updateAuthor(newNickName));
+    }
+
 }

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -104,4 +104,12 @@ public class MemberController {
         memberService.deleteMember(userId,deleteForm,res);
         return success("회원탈퇴에 성공했습니다.");
     }
+
+    @ApiOperation(value = "프로필 이미지 초기화",notes = "유저의 프로필 이미지를 초기화 합니다.")
+    @DeleteMapping("/profileimage")
+    public ApiResult<String> deleteProfileImage(HttpServletResponse res){
+        Long userId = authService.getUserIdFromJWT();
+        memberService.deleteProfileImage(userId);
+        return success("프로필 이미지가 초기화 되었습니다.");
+    }
 }

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -83,11 +83,10 @@ public class MemberController {
 
     @ApiOperation(value = "프로필 이미지 변경 / 닉네임 변경", notes = "변경사항이 있는 객체의 내용을 담아서 전송을 하면 유저의 정보가 변경.")
     @PutMapping("/image/nickname")
-    public ApiResult<String> uploadProfileImage(@RequestParam(value = "image",required = false) MultipartFile image,@RequestParam(value="nickName",required = false) String nickName)
+    public ApiResult<UpdateNickNameAndImageDto> uploadProfileImage(@RequestParam(value = "image",required = false) MultipartFile image,@RequestParam(value="nickName",required = false) String nickName)
         throws Exception {
         Long userId = authService.getUserIdFromJWT();
-        memberService.updateProfileImageAndNickName(image,nickName,userId);
-        return success("성공적으로 수정이 되었습니다");
+        return success(memberService.updateProfileImageAndNickName(image,nickName,userId));
     }
 
     @ApiOperation(value = "비밀번호 변경", notes = "changePassword(String) : 변경하고자하는 비밀번호, currentPassword(String) : 현재 비밀번호 를 넘겨주면 validation 후 비밀번호 변경.")

--- a/src/main/java/com/knu/cse/member/dto/UpdateNickNameAndImageDto.java
+++ b/src/main/java/com/knu/cse/member/dto/UpdateNickNameAndImageDto.java
@@ -1,0 +1,17 @@
+package com.knu.cse.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateNickNameAndImageDto {
+
+    private String newNickName;
+    private String newProFileImg;
+
+    public UpdateNickNameAndImageDto(){}
+
+    public UpdateNickNameAndImageDto(String newNickName,String newProFileImg){
+        this.newNickName=newNickName;
+        this.newProFileImg=newProFileImg;
+    }
+}

--- a/src/main/java/com/knu/cse/member/model/Member.java
+++ b/src/main/java/com/knu/cse/member/model/Member.java
@@ -84,6 +84,8 @@ public class Member extends BaseEntity {
         this.nickname=nickname;
     }
 
+    public void deleteProfileImage(){this.profileImageUrl=null;}
+
     public void deleteMember(){
         this.email = null;
         this.password = null;

--- a/src/main/java/com/knu/cse/member/service/MemberService.java
+++ b/src/main/java/com/knu/cse/member/service/MemberService.java
@@ -129,4 +129,11 @@ public class MemberService {
         res.addCookie(refreshToken);
     }
 
+    @Transactional
+    public void deleteProfileImage(Long userId){
+        Member member = memberRepository.findById(userId).orElseThrow(
+            () -> new NotFoundException("존재하지 않는 회원입니다."));
+        member.deleteProfileImage();
+    }
+
 }


### PR DESCRIPTION
## Pull Request

## 종류

- [x] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용

- 닉네임 수정시 댓글 및 게시물 저자까지 변하도록 수정하였습니다
- 또한 변경된 닉네임의 정보와 이미지 URL 까지 리턴하도록 추가하였습니다.
- 유저의 프로필 사진을 초기화하는 API를 만들었습니다.

## 변경로직


