### PR TITLE
FEAT: 비밀번호 찾기 기능 구현

### DIFF
--- a/src/main/java/com/knu/cse/email/service/AuthService.java
+++ b/src/main/java/com/knu/cse/email/service/AuthService.java
@@ -9,9 +9,6 @@ import com.knu.cse.member.dto.SignInForm;
 import com.knu.cse.member.dto.SignUpForm;
 import com.knu.cse.member.repository.MemberRepository;
 import com.knu.cse.member.security.SecurityMember;
-import java.util.Base64;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -136,13 +133,4 @@ public class AuthService {
         log.info(content);
     }
 
-    public String verifyPasswordChangeEmail(VerifyEmailDto verifyEmailDto) throws IllegalStateException{
-        String email = redisUtil.getData(verifyEmailDto.getCode());
-        if(email == null) throw new IllegalStateException("인증번호가 올바르지 않습니다.");
-        if(email.equals(verifyEmailDto.getEmail())) {
-            redisUtil.deleteData(verifyEmailDto.getCode());
-            return "인증을 성공적으로 수행하였습니다.";
-        }
-        throw new IllegalStateException("유효하지 않은 인증번호입니다.");
-    }
 }

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -61,7 +61,7 @@ public class MemberController {
         return success("회원가입을 성공적으로 완료했습니다.");
     }
 
-    @ApiOperation(value = "이메일 인증 번호 요청", notes = "회원가입 시 이메일 인증 번호를 요청하는 API")
+    @ApiOperation(value = "회원가입 인증번호 발급", notes = "회원가입 시 이메일 인증 번호를 요청하는 API")
     @GetMapping("/verify/{requestEmail}")
     public ApiResult<String> verify(@PathVariable("requestEmail") String requestEmail) throws NotFoundException {
         authService.sendVerificationMail(requestEmail);
@@ -124,10 +124,11 @@ public class MemberController {
     @ApiOperation(value = "비밀번호 찾기 인증번호 검증", notes = "회원 비밀번호를 찾기 위해 이메일로 발급한 임시 인증번호를 검증한다.")
     @PostMapping("/verifyPassword")
     public ApiResult<String> validateTemporalCode(@RequestBody VerifyEmailDto verifyEmailDto) throws IllegalStateException{
-        return success(authService.verifyPasswordChangeEmail(verifyEmailDto));
+        return success(authService.verifyEmail(verifyEmailDto));
     }
 
-    @ApiOperation(value = "비밀번호 찾기 검증 후 비밀번호 변경", notes = "이메일로 본인 인증을 거친 후 바로 비밀번호를 변경할 수 있다. \n email : 비밀번호를 바꾸려는 이메일\n password : 새로운 비밀번호")
+    @ApiOperation(value = "비밀번호 찾기 검증 후 비밀번호 변경", notes = "이메일로 본인 인증을 거친 후 바로 비밀번호를 변경할 수 있다."
+        + " \n email : 비밀번호를 바꾸려는 이메일\n permissionCode : 이메일로 보낸 인증 번호를 인증하면 서버로부터 받는 코드\n password : 새로운 비밀번호")
     @PostMapping("/changeValidatedPassword")
     public ApiResult<String> changeValidatedPassword(@Valid @RequestBody ValidatedPassowrdForm validatedPassowrdForm) throws NotFoundException{
         return success(memberService.changeValidatedPassword(validatedPassowrdForm));

--- a/src/main/java/com/knu/cse/member/controller/MemberController.java
+++ b/src/main/java/com/knu/cse/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import com.knu.cse.email.service.AuthService;
 import com.knu.cse.member.repository.MemberRepository;
 import com.knu.cse.member.service.MemberService;
 import com.knu.cse.utils.ApiUtils.ApiResult;
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
@@ -111,5 +112,24 @@ public class MemberController {
         Long userId = authService.getUserIdFromJWT();
         memberService.deleteProfileImage(userId);
         return success("프로필 이미지가 초기화 되었습니다.");
+    }
+
+    @ApiOperation(value = "비밀번호 찾기 인증번호 발급", notes = "회원 비밀번호를 찾기 위해 이메일로 임시 인증번호를 발급한다.")
+    @GetMapping("/findPassword/{requestEmail}")
+    public ApiResult<String> findPassword(@PathVariable("requestEmail") String email){
+        authService.sendPasswordChangeVerificationMail(email);
+        return success("성공적으로 인증 메일을 전송하였습니다.");
+    }
+
+    @ApiOperation(value = "비밀번호 찾기 인증번호 검증", notes = "회원 비밀번호를 찾기 위해 이메일로 발급한 임시 인증번호를 검증한다.")
+    @PostMapping("/verifyPassword")
+    public ApiResult<String> validateTemporalCode(@RequestBody VerifyEmailDto verifyEmailDto) throws IllegalStateException{
+        return success(authService.verifyPasswordChangeEmail(verifyEmailDto));
+    }
+
+    @ApiOperation(value = "비밀번호 찾기 검증 후 비밀번호 변경", notes = "이메일로 본인 인증을 거친 후 바로 비밀번호를 변경할 수 있다. \n email : 비밀번호를 바꾸려는 이메일\n password : 새로운 비밀번호")
+    @PostMapping("/changeValidatedPassword")
+    public ApiResult<String> changeValidatedPassword(@Valid @RequestBody ValidatedPassowrdForm validatedPassowrdForm) throws NotFoundException{
+        return success(memberService.changeValidatedPassword(validatedPassowrdForm));
     }
 }

--- a/src/main/java/com/knu/cse/member/dto/ChangePasswordForm.java
+++ b/src/main/java/com/knu/cse/member/dto/ChangePasswordForm.java
@@ -12,7 +12,7 @@ public class ChangePasswordForm {
     private String currentPassword;
 
     @NotNull
-    @Length(min = 8, max = 20, message = "비밀번호의 길이는 8에서 20사이여야 합니다!")
+    @Length(min = 8, max = 20, message = "비밀번호의 길이는 8에서 20 사이여야 합니다!")
     private String changePassword;
 
     public ChangePasswordForm(String currentPassword,

--- a/src/main/java/com/knu/cse/member/dto/ValidatedPassowrdForm.java
+++ b/src/main/java/com/knu/cse/member/dto/ValidatedPassowrdForm.java
@@ -9,6 +9,7 @@ import org.hibernate.validator.constraints.Length;
  *
  * [입력받는 파라미터]
  * 회원 이메일
+ * 인증번호 인증 시 서버로부터 받는 허락 코드
  * 새로운 비밀번호
  */
 

--- a/src/main/java/com/knu/cse/member/dto/ValidatedPassowrdForm.java
+++ b/src/main/java/com/knu/cse/member/dto/ValidatedPassowrdForm.java
@@ -1,0 +1,29 @@
+package com.knu.cse.member.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+/**
+ * 비밀번호 찾기 시 인증된 회원의 비밀번호 변경을 위한 DTO
+ *
+ * [입력받는 파라미터]
+ * 회원 이메일
+ * 새로운 비밀번호
+ */
+
+@Data
+public class ValidatedPassowrdForm {
+
+    private String email;
+
+    @NotNull
+    @Length(min = 8, max = 20, message = "비밀번호의 길이는 8에서 20 사이여야 합니다!")
+    private String password;
+
+    public ValidatedPassowrdForm(String email,
+        @NotNull @Length(min = 8, max = 20, message = "비밀번호의 길이는 8에서 20 사이여야 합니다!") String password) {
+        this.email = email;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/knu/cse/member/dto/ValidatedPassowrdForm.java
+++ b/src/main/java/com/knu/cse/member/dto/ValidatedPassowrdForm.java
@@ -17,6 +17,8 @@ public class ValidatedPassowrdForm {
 
     private String email;
 
+    private String permissionCode;
+
     @NotNull
     @Length(min = 8, max = 20, message = "비밀번호의 길이는 8에서 20 사이여야 합니다!")
     private String password;

--- a/src/main/java/com/knu/cse/member/service/MemberService.java
+++ b/src/main/java/com/knu/cse/member/service/MemberService.java
@@ -15,6 +15,7 @@ import com.knu.cse.member.dto.ChangePasswordForm;
 import com.knu.cse.member.dto.DeleteForm;
 import com.knu.cse.member.dto.LoginSuccessDto;
 import com.knu.cse.member.dto.UpdateNickNameAndImageDto;
+import com.knu.cse.member.dto.ValidatedPassowrdForm;
 import com.knu.cse.member.model.Member;
 import com.knu.cse.member.repository.MemberRepository;
 import java.io.IOException;
@@ -136,4 +137,12 @@ public class MemberService {
         member.deleteProfileImage();
     }
 
+    @Transactional
+    public String changeValidatedPassword(ValidatedPassowrdForm validatedPassowrdForm) throws NotFoundException{
+        String email = validatedPassowrdForm.getEmail();
+        Member member = memberRepository.findByEmail(email).orElseThrow(
+            () -> new NotFoundException("존재하지 않는 회원입니다."));
+        member.changePassword(passwordEncoder.encode(validatedPassowrdForm.getPassword()));
+        return "성공적으로 비밀번호를 변경하였습니다.";
+    }
 }

--- a/src/main/java/com/knu/cse/member/service/MemberService.java
+++ b/src/main/java/com/knu/cse/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.knu.cse.deletemember.repository.DeleteMemberRepository;
 import com.knu.cse.email.service.AuthService;
 import com.knu.cse.email.util.CookieUtil;
 import com.knu.cse.email.util.JwtUtil;
+import com.knu.cse.email.util.RedisUtil;
 import com.knu.cse.errors.NotFoundException;
 import com.knu.cse.image.S3UploadService;
 import com.knu.cse.member.dto.ChangePasswordForm;
@@ -44,8 +45,8 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final AuthService authService;
     private final DeleteMemberRepository deleteMemberRepository;
-
     private final CookieUtil cookieUtil;
+    private final RedisUtil redisUtil;
 
     @Transactional
     public UpdateNickNameAndImageDto updateProfileImageAndNickName(MultipartFile image,String newNickName,Long userId) throws Exception {
@@ -142,6 +143,13 @@ public class MemberService {
         String email = validatedPassowrdForm.getEmail();
         Member member = memberRepository.findByEmail(email).orElseThrow(
             () -> new NotFoundException("존재하지 않는 회원입니다."));
+
+        String permittedEmail = redisUtil.getData(validatedPassowrdForm.getPermissionCode());
+        redisUtil.deleteData(validatedPassowrdForm.getPermissionCode());
+
+        if(permittedEmail == null || !permittedEmail.equals(email)){
+            throw new IllegalArgumentException("이메일 인증이 올바르게 수행되지 않았습니다.");
+        }
         member.changePassword(passwordEncoder.encode(validatedPassowrdForm.getPassword()));
         return "성공적으로 비밀번호를 변경하였습니다.";
     }


### PR DESCRIPTION
## Pull Request

## 종류

- [X] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용
- 비밀번호 찾기 기능 구현

## 변경 로직
- 비밀번호 찾기 시 이메일로 인증 번호를 전송

- 이메일로 보낸 인증 번호를 인증 받으면 `permissionCode` 반환

- 새로운 비밀번호 입력 시 `permissionCode` 가 있어야만 변경 가능
    - 허가 받지 않은 변경 요청이 들어올 수 있어서 보안을 강화하기 위해 이중 인증 방식 구현


