### PR TITLE
FEAT : 자동반납 기능 구현

### DIFF
--- a/src/main/java/com/knu/cse/classseat/domain/ClassSeat.java
+++ b/src/main/java/com/knu/cse/classseat/domain/ClassSeat.java
@@ -26,7 +26,7 @@ public class ClassSeat extends BaseEntity {
     @JoinColumn(name="room_id")
     private ClassRoom classRoom;
 
-    @OneToOne(fetch=FetchType.LAZY,mappedBy = "classSeat")
+    @OneToOne(mappedBy = "classSeat")
     private Reservation reservation;
 
     @Version

--- a/src/main/java/com/knu/cse/config/RedisListenerConfiguration.java
+++ b/src/main/java/com/knu/cse/config/RedisListenerConfiguration.java
@@ -1,0 +1,18 @@
+package com.knu.cse.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisListenerConfiguration {
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+        redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+        return redisMessageListenerContainer;
+    }
+
+}

--- a/src/main/java/com/knu/cse/email/util/RedisKeyExpiredListener.java
+++ b/src/main/java/com/knu/cse/email/util/RedisKeyExpiredListener.java
@@ -1,0 +1,47 @@
+package com.knu.cse.email.util;
+
+import com.knu.cse.classseat.domain.ClassSeat;
+import com.knu.cse.errors.NotFoundException;
+import com.knu.cse.reservation.domain.Reservation;
+import com.knu.cse.reservation.repository.ReservationRepository;
+import com.knu.cse.reservation.service.ReservationService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class RedisKeyExpiredListener extends KeyExpirationEventMessageListener {
+
+    @Autowired
+    private ReservationService reservationService;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    /**
+     * Creates new {@link MessageListener} for {@code __keyevent@*__:expired} messages.
+     *
+     * @param listenerContainer must not be {@literal null}.
+     */
+    public RedisKeyExpiredListener(RedisMessageListenerContainer listenerContainer) {
+        super(listenerContainer);
+    }
+
+    @Override
+    public void onMessage(Message message, byte[] pattern){
+        String[] key = message.toString().split(",");
+//        System.out.println("onMessage pattern " + new String(pattern) + " | " + key[0]);
+        if (key[0].equals("reservation")){
+//            System.out.println(" reservation 만료 : " + key[1]);
+            long lkey = Long.parseLong(key[1]);
+            reservationService.unreservedById(lkey);
+        }
+//        else{
+//            System.out.println(" 다른게 redis 만료됨. ");
+//        }
+
+    }
+}

--- a/src/main/java/com/knu/cse/reservation/domain/Reservation.java
+++ b/src/main/java/com/knu/cse/reservation/domain/Reservation.java
@@ -20,11 +20,11 @@ public class Reservation extends BaseTimeEntity {
     private LocalDateTime dueDate;
     private Long extensionNum;
 
-    @OneToOne(fetch=FetchType.LAZY)
+    @OneToOne
     @JoinColumn(name = "seat_id")
     private ClassSeat classSeat;
 
-    @OneToOne(fetch=FetchType.LAZY)
+    @OneToOne
     @JoinColumn(name = "member_id")
     private Member member;
 
@@ -43,7 +43,7 @@ public class Reservation extends BaseTimeEntity {
     }
 
     public void updateTime(){
-        this.dueDate = this.dueDate.plusHours(6);
+        this.dueDate = LocalDateTime.now().plusHours(6);
     }
 
     public void upExtensionNum(){

--- a/src/main/java/com/knu/cse/reservationsave/domain/ReservationSave.java
+++ b/src/main/java/com/knu/cse/reservationsave/domain/ReservationSave.java
@@ -1,0 +1,60 @@
+package com.knu.cse.reservationsave.domain;
+
+import com.knu.cse.classroom.domain.Building;
+import com.knu.cse.member.model.Gender;
+import com.knu.cse.member.model.Major;
+import com.knu.cse.member.model.Member;
+import com.knu.cse.member.model.MemberRole;
+import com.knu.cse.reservation.domain.Reservation;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReservationSave {
+
+    @Id @GeneratedValue
+    @Column(name = "reservatoin_save_id")
+    private Long id;
+
+    private Building building;
+    private Long roomNumber;
+    private Long seatNumber;
+
+    private String email;
+    private String username;
+    private String studentId;
+    private Major major;
+
+    private LocalDateTime startTime;
+
+    private Boolean returnCheck;
+
+
+    @Builder
+    public ReservationSave(Building building, Long roomNumber, Long seatNumber,
+                           Member member,
+                           LocalDateTime startTime,Boolean returnCheck){
+        this.building = building;
+        this.roomNumber = roomNumber;
+        this.seatNumber = seatNumber;
+
+        this.email= member.getEmail();
+        this.username = member.getUsername();
+        this.studentId = member.getStudentId();
+        this.major = member.getMajor();
+
+        this.startTime = startTime;
+        this.returnCheck = returnCheck;
+    }
+
+}

--- a/src/main/java/com/knu/cse/reservationsave/repository/ReservationSaveRepository.java
+++ b/src/main/java/com/knu/cse/reservationsave/repository/ReservationSaveRepository.java
@@ -1,0 +1,7 @@
+package com.knu.cse.reservationsave.repository;
+
+import com.knu.cse.reservationsave.domain.ReservationSave;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationSaveRepository extends JpaRepository<ReservationSave, Long> {
+}


### PR DESCRIPTION
## Pull Request

## 종류

- [x] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [x] Refactor

## 작업 내용
RedisListenerConfiguration
- redis expire listener 환경설정

RedisKeyExpiredListener
- redis expire 시 수행되는 부분
- 예약의 경우 redis key로 "reservation,{reservation PK}"로 저장됨.
- redis가 expire 시 reservation의 경우(예약한 뒤 6시간 후 자동 반납), 해당 reservation 디비 삭제

ReservationSave
- 예약기록을 보관하기 위한 DB table
- 필드에는 건물, 강의실 번호, 좌석 번호, email, username, 학번, 전공, 해당 시각, returnCheck(예약 -> false, 반납 -> true)로 저장된다.

ReservationService
- 예약 반납 -> 해당 reservation row를 삭제 및 reservatoinSave에 저장함, redis에 저장되어있는 key:value 삭제
- 자동 반납 -> 해당 reservation row를 삭제함
- 예약하기 -> reservation row를 생성 및 reservationSave에 저장함, redis에 key : value = "reservation,{reservation PK}" : {member PK} 저장
- 좌석 연장 -> redis timeout을 6시간으로 재설정함.

## 변경로직
좌석을 연장 시 기존에는 처음 예약한 시각에서 6시간을 더해주었지만, 현재는 연장한 시각에서 6시간을 더해줌.

