### PR TITLE
FEAT: Admin board 관련 컨트롤러에 관리자권한 확인하는 인터셉터 추가

### DIFF
--- a/src/main/java/com/knu/cse/config/InterceptorConfig.java
+++ b/src/main/java/com/knu/cse/config/InterceptorConfig.java
@@ -1,0 +1,19 @@
+package com.knu.cse.config;
+
+import com.knu.cse.member.security.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class InterceptorConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor);
+    }
+}

--- a/src/main/java/com/knu/cse/member/security/Auth.java
+++ b/src/main/java/com/knu/cse/member/security/Auth.java
@@ -1,0 +1,15 @@
+package com.knu.cse.member.security;
+
+
+
+import com.knu.cse.member.model.MemberRole;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE,ElementType.METHOD})
+public @interface Auth {
+    MemberRole role() default MemberRole.ROLE_ADMIN;
+}

--- a/src/main/java/com/knu/cse/member/security/AuthInterceptor.java
+++ b/src/main/java/com/knu/cse/member/security/AuthInterceptor.java
@@ -1,0 +1,72 @@
+package com.knu.cse.member.security;
+
+import com.knu.cse.email.service.AuthService;
+import com.knu.cse.errors.NotFoundException;
+import com.knu.cse.member.model.Member;
+import com.knu.cse.member.model.MemberRole;
+import com.knu.cse.member.repository.MemberRepository;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+
+@RequiredArgsConstructor
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
+
+        if( handler instanceof HandlerMethod == false ) {
+            return true;
+        }
+        HandlerMethod handlerMethod = (HandlerMethod)handler;
+
+        // @Auth 받아오기
+        Auth auth = handlerMethod.getMethodAnnotation(Auth.class);
+        Auth adminRole = handlerMethod.getMethod().getDeclaringClass().getAnnotation(Auth.class);
+
+        if( auth == null && adminRole == null) {
+            return true;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if( authentication.getPrincipal().equals("anonymousUser") ) {
+            response.sendRedirect(request.getContextPath() + "/home/");
+            return false;
+        }
+
+        SecurityMember securityMember = (SecurityMember) authentication.getPrincipal();
+
+        String email = securityMember.getEmail();
+        if ( email == null ) {
+            response.sendRedirect(request.getContextPath() + "/home/");
+            return false;
+        }
+
+        Member member = memberRepository.findByEmail(email).orElseThrow(() ->
+            new NotFoundException("존재하지 않는 회원입니다."));
+
+        String role = adminRole.role().toString();
+        if(MemberRole.ROLE_ADMIN.equals(role) ) {
+            if(MemberRole.ROLE_ADMIN.equals(member.getRole())){
+                response.sendRedirect(request.getContextPath() + "/home/");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/knu/cse/member/security/AuthInterceptor.java
+++ b/src/main/java/com/knu/cse/member/security/AuthInterceptor.java
@@ -43,7 +43,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if( authentication.getPrincipal().equals("anonymousUser") ) {
-            response.sendRedirect(request.getContextPath() + "/home/");
+            response.sendRedirect(request.getContextPath() + "/unauthorized");
             return false;
         }
 
@@ -51,17 +51,18 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         String email = securityMember.getEmail();
         if ( email == null ) {
-            response.sendRedirect(request.getContextPath() + "/home/");
+            response.sendRedirect(request.getContextPath() + "/unauthorized");
             return false;
         }
 
         Member member = memberRepository.findByEmail(email).orElseThrow(() ->
             new NotFoundException("존재하지 않는 회원입니다."));
 
-        String role = adminRole.role().toString();
+        MemberRole role = adminRole.role(); // 어노테이션에서 설정한 Role
+
         if(MemberRole.ROLE_ADMIN.equals(role) ) {
-            if(MemberRole.ROLE_ADMIN.equals(member.getRole())){
-                response.sendRedirect(request.getContextPath() + "/home/");
+            if(!MemberRole.ROLE_ADMIN.equals(member.getRole())){
+                response.sendRedirect(request.getContextPath() + "/unauthorized");
                 return false;
             }
         }

--- a/src/main/java/com/knu/cse/web/controller/HomeController.java
+++ b/src/main/java/com/knu/cse/web/controller/HomeController.java
@@ -62,9 +62,6 @@ public class HomeController {
             redisUtil.setDataExpire(refreshJwt, member.getEmail(), JwtUtil.REFRESH_TOKEN_VALIDATION_SECOND);
             res.addCookie(accessToken);
             res.addCookie(refreshToken);
-
-
-
             return "home";
         }
         catch (Exception e){
@@ -72,6 +69,11 @@ public class HomeController {
             bindingResult.reject("loginFail",e.getMessage());
             return "login";
         }
+    }
+
+    @GetMapping("/unauthorized")
+    public String unauthorized(){
+        return "unauthorized";
     }
 
 }

--- a/src/main/java/com/knu/cse/web/controller/WebBoardController.java
+++ b/src/main/java/com/knu/cse/web/controller/WebBoardController.java
@@ -10,6 +10,8 @@ import com.knu.cse.comment.service.CommentService;
 import com.knu.cse.email.service.AuthService;
 import com.knu.cse.errors.NotFoundException;
 import com.knu.cse.errors.UnauthorizedException;
+import com.knu.cse.member.model.MemberRole;
+import com.knu.cse.member.security.Auth;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Auth(role = MemberRole.ROLE_MANAGER)
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/admin")
@@ -32,7 +35,6 @@ public class WebBoardController {
 
     private final BoardService boardService;
     private final CommentService commentService;
-
     private final AuthService authService;
 
     @GetMapping("/boardlist")

--- a/src/main/java/com/knu/cse/web/controller/WebBoardController.java
+++ b/src/main/java/com/knu/cse/web/controller/WebBoardController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@Auth(role = MemberRole.ROLE_MANAGER)
+@Auth
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/admin")

--- a/src/main/resources/templates/unauthorized.html
+++ b/src/main/resources/templates/unauthorized.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+</head>
+<body>
+<h2>현재 관리자 계정이 아닙니다. 접근 권한이 없습니다.</h2>
+</body>
+</html>


### PR DESCRIPTION
## Pull Request

## 종류

- [x] New Feature
- [ ] Bug Fix
- [ ] Setup
- [ ] Chore
- [ ] Test
- [ ] Refactor

## 작업 내용

1. admin/board 컨트롤러에 관리자 권한인지 확인하는 인터셉터를 추가

사용방법으로는 사용하려는 admin 컨트롤러 클래스에 @Auth 어노테이션을 붙이면 됩니다.

+ 만약 메서드별로 따로 적용하도록 한다면 추후에 추가 구현이 필요합니다. ( 필요시 추가 구현 하겠습니다 ! )

## 변경로직


